### PR TITLE
修改download.py逻辑，解决requst直接抛出异常退出的问题。

### DIFF
--- a/download.py
+++ b/download.py
@@ -5,26 +5,32 @@ import os
 def download(localFile, srcUrl):
 	print("------------------------------------------------------------")
 	print('Downloading %s' % localFile, end='\r')
-	with requests.get(srcUrl, stream=True) as r:
-		if r.status_code != 200:
-			print("retrying")
-			return download(localFile, srcUrl)
-		contentLength = int(r.headers['content-length'])
-		print('Downloading %s %.2f MB' % (localFile, contentLength/1024/1024))
-		downSize = 0
-		startTime = time.time()
-		with open(localFile+".temp", 'wb') as f:
-			for chunk in r.iter_content(8192):
-				if chunk:
-					f.write(chunk)
-				downSize += len(chunk)
-				line = '%.1f%% - %.2f MB/s - %.2f MB          '
-				line = line % (downSize/contentLength*100, downSize/1024/1024/(time.time()-startTime), downSize/1024/1024)
-				print(line, end='\r')
-				if downSize >= contentLength:
-					break
-		os.rename(localFile+".temp", localFile)
-		print()
+	try:
+		with requests.get(srcUrl, stream=True) as r:
+			if r.status_code != 200:
+				print("retrying")
+				return download(localFile, srcUrl)
+			contentLength = int(r.headers['content-length'])
+			print('Downloading %s %.2f MB' % (localFile, contentLength/1024/1024))
+			downSize = 0
+			startTime = time.time()
+			with open(localFile+".temp", 'wb') as f:
+				for chunk in r.iter_content(8192):
+					if chunk:
+						f.write(chunk)
+					downSize += len(chunk)
+					line = '%.1f%% - %.2f MB/s - %.2f MB          '
+					line = line % (downSize/contentLength*100, downSize/1024/1024/(time.time()-startTime), downSize/1024/1024)
+					print(line, end='\r')
+					if downSize >= contentLength:
+						break
+			os.rename(localFile+".temp", localFile)
+			print()
+	except:
+		print("exception wait 180s")
+		time.sleep(180)
+		return download(localFile, srcUrl)
+      
 
 Block_Files = {
 	"0to999999_Block.zip":			"https://link.jscdn.cn/sharepoint/aHR0cHM6Ly9vYmRvdGEtbXkuc2hhcmVwb2ludC5jbi86dTovZy9wZXJzb25hbC90Y3pwbF9vYmRvdGFfcGFydG5lcl9vbm1zY2hpbmFfY24vRVExUUJSVnpUQk5IdmZSNWxxZTBlVnNCSzNTSXlLakk5WXBFSlpvN2RXNFkwUT9lPVg0UmFXTw==.zip",

--- a/download.py
+++ b/download.py
@@ -3,6 +3,11 @@ import requests
 import os
 
 def download(localFile, srcUrl):
+	if os.path.exists(localFile+".temp"):
+		os.remove(localFile+".temp")
+	if os.path.exists(localFile):
+		print(localFile+"exist!\n")
+		return
 	print("------------------------------------------------------------")
 	print('Downloading %s' % localFile, end='\r')
 	try:
@@ -27,8 +32,9 @@ def download(localFile, srcUrl):
 			os.rename(localFile+".temp", localFile)
 			print()
 	except:
-		print("exception wait 180s")
-		time.sleep(180)
+		print("exception wait 180s\n")
+		time.sleep(360)
+		print("retry\n")
 		return download(localFile, srcUrl)
       
 


### PR DESCRIPTION
1.request容易抛出异常导致程序直接退出，增加try-catch结构，line34-38。
2.下载文件前增加检测本地是否存在临时文件和下载完成的文件，如果有临时文件则删除，如果有下载完的文件则跳过 line6-10。